### PR TITLE
Tweak import regex to support dynamic imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ function resolvePath (root, filepath, url) {
 
 function transformJs (root, filepath, src) {
 	return src
-		.replace(/import\s+(|[\{\*\w][^"']*)["']([^"']+)["'][\t ]*($|;|\/\/|\/\*)/gm,
-			(match, pre, url, post) => `import ${pre}'${resolvePath(root, filepath, url)}'${post}`)
+		.replace(/import(\s*\(?)(|[\{\*\w][^"']*)["']([^"']+)["'][\t ]*($|;|\/\/|\/\*|\))/gm,
+			(match, s, pre, url, post) => `import${s}${pre}'${resolvePath(root, filepath, url)}'${post}`)
 		.replace(/export\s+([\{\*\w][^"']*)\s*from\s*["']([^"']+)["'][\t ]*($|;|\/\/|\/\*)/gm,
 			(match, pre, url, post) => `export ${pre} from '${resolvePath(root, filepath, url)}'${post}`)
 }


### PR DESCRIPTION
This makes a couple of small tweaks to the `import` regular expression to support dynamic imports.

* Allows 0 or more spaces, followed by an optional `(`, after `import` instead of 1 or more spaces